### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
         sudo mv versionhelper /usr/local/bin/versionhelper
         rm versionhelper.tar.gz
 
-        echo "::set-output name=version::$(versionhelper common --counter=${{ inputs.counter }} --debug=${{ inputs.debug }})"
+        echo "version=$(versionhelper common --counter=${{ inputs.counter }} --debug=${{ inputs.debug }})" >> $GITHUB_OUTPUT
 
         if [[ "${{ inputs.labels }}" != "" ]] ; then
           versionhelper version append --labels=${{ inputs.labels }} --debug=${{ inputs.debug }}


### PR DESCRIPTION
## Description

Revert [31ff5bc](https://github.com/krafton-hq/version-helper/commit/31ff5bc)

Update `action.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

> Deprecated된 `set-output` 명령 대신 환경 파일을 사용하도록 `action.yml`을 업데이트합니다.
> 자세한 내용은 https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 을 참조하세요.
> 
> 아래의 명령을 통해 `set-output` 명령을 사용하는 워크플로우 파일을 발견했습니다:
> 
> ```bash
> $ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
> ```

**AS-IS**

```yaml
echo "::set-output name=version::$(versionhelper common --counter=${{ inputs.counter }} --debug=${{ inputs.debug }})"
```

**TO-BE**

```yaml
echo "version=$(versionhelper common --counter=${{ inputs.counter }} --debug=${{ inputs.debug }})" >> $GITHUB_OUTPUT
```